### PR TITLE
Add scm section to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
     <name>Synopsys</name>
     <url>https://www.synopsys.com/software-integrity.html</url>
   </organization>
+  <scm>
+    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <tag>HEAD</tag>
+  </scm>
   <build>
     <testResources>
       <testResource>


### PR DESCRIPTION
To allow mvn release:prepare task to write to correct github repo. Without this it gets the scm info from parent pom and tries to push to jenkinsci/plugin-pom.git/defensics.