### PR TITLE
Make sure getDisplayName works with mocks

### DIFF
--- a/src/main/java/com/synopsys/defensics/jenkins/FuzzBuildStep.java
+++ b/src/main/java/com/synopsys/defensics/jenkins/FuzzBuildStep.java
@@ -146,7 +146,7 @@ public class FuzzBuildStep extends Builder implements SimpleBuildStep {
     @Nonnull
     @Override
     public String getDisplayName() {
-      return pluginConfiguration.getDisplayName();
+      return PluginConfiguration.DISPLAY_NAME;
     }
 
     /**

--- a/src/main/java/com/synopsys/defensics/jenkins/FuzzPipelineStep.java
+++ b/src/main/java/com/synopsys/defensics/jenkins/FuzzPipelineStep.java
@@ -265,7 +265,7 @@ public class FuzzPipelineStep extends Step {
     @Nonnull
     @Override
     public String getDisplayName() {
-      return pluginConfiguration.getDisplayName();
+      return PluginConfiguration.DISPLAY_NAME;
     }
 
     public List<InstanceConfiguration> getDefensicsInstances() {

--- a/src/main/java/com/synopsys/defensics/jenkins/FuzzPostBuildStep.java
+++ b/src/main/java/com/synopsys/defensics/jenkins/FuzzPostBuildStep.java
@@ -155,7 +155,7 @@ public class FuzzPostBuildStep extends Recorder implements SimpleBuildStep {
     @Nonnull
     @Override
     public String getDisplayName() {
-      return pluginConfiguration.getDisplayName();
+      return PluginConfiguration.DISPLAY_NAME;
     }
 
     /**

--- a/src/main/java/com/synopsys/defensics/jenkins/configuration/PluginConfiguration.java
+++ b/src/main/java/com/synopsys/defensics/jenkins/configuration/PluginConfiguration.java
@@ -29,6 +29,8 @@ import org.kohsuke.stapler.StaplerRequest;
 public class PluginConfiguration extends GlobalConfiguration {
   /** Plugin short name. Used e.g. when fetching plugin version number. */
   public static final String DEFENSICS_PLUGIN_NAME = "defensics";
+  /** Display name for both configuration and steps. */
+  public static final String DISPLAY_NAME = "Defensics fuzz test";
 
   private final transient InstanceConfigurationValidator instanceConfigurationValidator =
       new InstanceConfigurationValidator();
@@ -63,7 +65,7 @@ public class PluginConfiguration extends GlobalConfiguration {
   @Nonnull
   @Override
   public String getDisplayName() {
-    return "Defensics fuzz test";
+    return DISPLAY_NAME;
   }
 
   /**

--- a/src/test/java/com/synopsys/defensics/jenkins/FuzzBuildStepTest.java
+++ b/src/test/java/com/synopsys/defensics/jenkins/FuzzBuildStepTest.java
@@ -23,9 +23,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.mock;
 
+import jenkins.model.Jenkins;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.lang.reflect.Field;
+
 public class FuzzBuildStepTest {
 
   FuzzBuildStep fuzzBuildStep;
@@ -55,5 +60,16 @@ public class FuzzBuildStepTest {
   @Test
   public void testGetSettingFilePath() {
     assertThat(fuzzBuildStep.getConfigurationFilePath(), is(equalTo(SETTING_FILE_PATH)));
+  }
+
+  @Test
+  public void testDisplayName() throws NoSuchFieldException, IllegalAccessException {
+    Jenkins jenkins = mock(Jenkins.class);
+    Jenkins.JenkinsHolder holder = () -> jenkins;
+    Field holderField = Jenkins.class.getDeclaredField("HOLDER");
+    holderField.setAccessible(true);
+    holderField.set(null, holder);
+    FuzzBuildStep.FuzzBuildStepDescriptor descriptor = new FuzzBuildStep.FuzzBuildStepDescriptor();
+    assertThat(descriptor.getDisplayName(), is(notNullValue()));
   }
 }


### PR DESCRIPTION
When generating the docs, Jenkins mock is used and for defensics plugin the getDisplayName method fails with an exception: https://ci.jenkins.io/job/Infra/job/pipeline-steps-doc-generator/job/master/lastStableBuild/console 

As a result https://www.jenkins.io/doc/pipeline/steps/defensics/ is missing some human readable description for the steps. This PR should fix it.