### PR TITLE
Fix Windows CI tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <surefire.rerunFailingTestsCount>0</surefire.rerunFailingTestsCount>
   </properties>
   <name>Defensics</name>
   <description>Synopsys Defensics plugin for fuzz testing.</description>

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/InstanceConfigurationIT.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/InstanceConfigurationIT.java
@@ -111,7 +111,7 @@ public class InstanceConfigurationIT {
 
       assertThat(result.kind, is(equalTo(Kind.OK)));
     } finally {
-      mockServer.stop();
+      DefensicsMockServer.stopMockServer(mockServer);
     }
   }
 

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/InstanceConfigurationIT.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/InstanceConfigurationIT.java
@@ -101,11 +101,12 @@ public class InstanceConfigurationIT {
   @Test
   public void testConnectionTest() {
     ClientAndServer mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(
-        true, "PASS", RunState.COMPLETED);
-    defensicsMockServer.initServer(mockServer);
-
     try {
+      DefensicsMockServer defensicsMockServer = new DefensicsMockServer(
+          true, "PASS", RunState.COMPLETED
+      );
+      defensicsMockServer.initServer(mockServer);
+
       FormValidation result = defensicsInstanceConfigurationDescriptor.doTestConnection(
           LOCAL_URL, CERTIFICATE_VALIDATION_ENABLED, credentialsId);
 

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/ResultIT.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/ResultIT.java
@@ -79,6 +79,7 @@ public class ResultIT {
     EnvVars env = prop.getEnvVars();
     env.put("DEFENSICS_MAX_POLLING_INTERVAL", "1");
     jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);
+    mockServer = ClientAndServer.startClientAndServer(1080);
   }
 
   @After
@@ -88,9 +89,8 @@ public class ResultIT {
 
   @Test
   public void testPublishReport() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
-    mockServer.initServer(ResultIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(ResultIT.mockServer);
 
     try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
       List<String> expectedTabNames = Collections.singletonList(SETTING_FILE_PATH);
@@ -109,7 +109,6 @@ public class ResultIT {
 
   @Test
   public void testPublishReportWithFailures() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
     DefensicsMockServer mockServer = new DefensicsMockServer(false, "FAIL", RunState.COMPLETED);
     mockServer.initServer(ResultIT.mockServer);
 
@@ -130,7 +129,6 @@ public class ResultIT {
 
   @Test
   public void testPublishMultipleReports() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
     DefensicsMockServer mockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
     mockServer.initServer(ResultIT.mockServer);
 
@@ -190,9 +188,8 @@ public class ResultIT {
 
   @Test
   public void testTrendGraph() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
-    mockServer.initServer(ResultIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(ResultIT.mockServer);
 
     try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
       project.scheduleBuild2(0).get();
@@ -211,9 +208,8 @@ public class ResultIT {
 
   @Test
   public void testTrendGraphSomeBuildsHaveNoDefensicsResults() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
-    mockServer.initServer(ResultIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(ResultIT.mockServer);
 
     try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
       project.scheduleBuild2(0).get();
@@ -234,9 +230,8 @@ public class ResultIT {
 
   @Test
   public void testTrendGraphNotShownWhenTooFewResults() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
-    mockServer.initServer(ResultIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(ResultIT.mockServer);
 
     try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
       project.scheduleBuild2(0).get();
@@ -254,9 +249,8 @@ public class ResultIT {
 
   @Test
   public void testResultPackagePublishIsDisabledByDefault() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
-    mockServer.initServer(ResultIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(ResultIT.mockServer);
 
     try (JenkinsRule.WebClient webClient = jenkinsRule.createWebClient()) {
       final FreeStyleBuild build = project.scheduleBuild2(0).get();
@@ -268,9 +262,8 @@ public class ResultIT {
 
   @Test
   public void testResultPackagePublish() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
-    mockServer.initServer(ResultIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(ResultIT.mockServer);
 
     ProjectUtils.addBuildStep(project, NAME, SETTING_FILE_PATH, true);
 
@@ -286,9 +279,8 @@ public class ResultIT {
 
   @Test
   public void testMultipleResultPackages() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
-    mockServer.initServer(ResultIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(false, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(ResultIT.mockServer);
 
     ProjectUtils.addBuildStep(project, NAME, SETTING_FILE_PATH, true);
     ProjectUtils.addPostBuildStep(project, NAME, SETTING_FILE_PATH, true);

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/ResultIT.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/ResultIT.java
@@ -83,7 +83,7 @@ public class ResultIT {
 
   @After
   public void stopServer() {
-    mockServer.stop();
+    DefensicsMockServer.stopMockServer(mockServer);
   }
 
   @Test

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/RunFreestyleIT.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/RunFreestyleIT.java
@@ -67,7 +67,7 @@ public class RunFreestyleIT {
 
   @After
   public void stopServer() {
-    mockServer.stop();
+    DefensicsMockServer.stopMockServer(mockServer);
   }
 
   @Test
@@ -225,5 +225,4 @@ public class RunFreestyleIT {
     assertThat(project.getAction(HtmlReportAction.class).getUrlName(),
         is(equalTo(run.getActions(HtmlReportAction.class).get(0).getUrlName())));
   }
-
 }

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/RunFreestyleIT.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/RunFreestyleIT.java
@@ -63,6 +63,7 @@ public class RunFreestyleIT {
     EnvVars env = prop.getEnvVars();
     env.put("DEFENSICS_MAX_POLLING_INTERVAL", "1");
     jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);
+    mockServer = ClientAndServer.startClientAndServer(1080);
   }
 
   @After
@@ -72,9 +73,8 @@ public class RunFreestyleIT {
 
   @Test
   public void testRunBuildStep() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
-    mockServer.initServer(this.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(this.mockServer);
     ProjectUtils.setupProject(
         jenkinsRule,
         project,
@@ -96,9 +96,8 @@ public class RunFreestyleIT {
 
   @Test
   public void testRunPostBuildStep() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
-    mockServer.initServer(this.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(this.mockServer);
     ProjectUtils.setupProject(
         jenkinsRule,
         project,
@@ -120,9 +119,8 @@ public class RunFreestyleIT {
 
   @Test
   public void testConfigurationRoundTripAndRun() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
-    mockServer.initServer(this.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(this.mockServer);
     ProjectUtils.setupProject(
         jenkinsRule,
         project,
@@ -146,11 +144,8 @@ public class RunFreestyleIT {
 
   @Test
   public void testAbortJob() throws Exception {
-    // Create and use new client to prevent Job from completing.
-    // client = ApiUtils.getMockClient(JobState.RUNNING, 0);
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
-    mockServer.initServer(this.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(this.mockServer);
     ProjectUtils.setupProject(
         jenkinsRule,
         project,
@@ -179,9 +174,8 @@ public class RunFreestyleIT {
 
   @Test
   public void testJobFailed() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "PASS", RunState.ERROR);
-    mockServer.initServer(this.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "PASS", RunState.ERROR);
+    defensicsMockServer.initServer(this.mockServer);
     ProjectUtils.setupProject(
         jenkinsRule,
         project,
@@ -203,9 +197,8 @@ public class RunFreestyleIT {
 
   @Test
   public void testJobFailure() throws Exception {
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "FAIL", RunState.COMPLETED);
-    mockServer.initServer(this.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "FAIL", RunState.COMPLETED);
+    defensicsMockServer.initServer(this.mockServer);
 
     ProjectUtils.setupProject(
         jenkinsRule,

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/RunPipelineIT.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/RunPipelineIT.java
@@ -68,6 +68,7 @@ public class RunPipelineIT {
     EnvVars env = prop.getEnvVars();
     env.put("DEFENSICS_MAX_POLLING_INTERVAL", "1");
     jenkinsRule.jenkins.getGlobalNodeProperties().add(prop);
+    mockServer = ClientAndServer.startClientAndServer(1080);
   }
 
   @After
@@ -78,9 +79,8 @@ public class RunPipelineIT {
   @Test
   public void testRun() throws Exception {
     project.setDefinition(new CpsFlowDefinition(PIPELINE_SCRIPT, true));
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
-    mockServer.initServer(RunPipelineIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(RunPipelineIT.mockServer);
 
     ProjectUtils.setupProject(
         jenkinsRule,
@@ -103,9 +103,8 @@ public class RunPipelineIT {
   @Test
   public void testRunJobWithFailures() throws Exception {
     project.setDefinition(new CpsFlowDefinition(PIPELINE_SCRIPT, true));
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "FAIL", RunState.COMPLETED);
-    mockServer.initServer(RunPipelineIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "FAIL", RunState.COMPLETED);
+    defensicsMockServer.initServer(RunPipelineIT.mockServer);
     ProjectUtils.setupProject(
         jenkinsRule,
         project,
@@ -130,9 +129,8 @@ public class RunPipelineIT {
   @Test
   public void testAbortJob() throws Exception {
     // Create and use new client to prevent Job from completing.
-    mockServer = ClientAndServer.startClientAndServer(1080);
-    DefensicsMockServer mockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
-    mockServer.initServer(RunPipelineIT.mockServer);
+    DefensicsMockServer defensicsMockServer = new DefensicsMockServer(true, "PASS", RunState.COMPLETED);
+    defensicsMockServer.initServer(RunPipelineIT.mockServer);
     ProjectUtils.setupProject(
         jenkinsRule,
         project,
@@ -167,7 +165,6 @@ public class RunPipelineIT {
   @Test
   public void testJobFailed() throws Exception {
     project.setDefinition(new CpsFlowDefinition(PIPELINE_SCRIPT, true));
-    mockServer = ClientAndServer.startClientAndServer(1080);
     DefensicsMockServer mockServer = new DefensicsMockServer(true, "PASS", RunState.ERROR);
     mockServer.initServer(RunPipelineIT.mockServer);
     ProjectUtils.setupProject(

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/RunPipelineIT.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/RunPipelineIT.java
@@ -20,7 +20,6 @@ import static com.synopsys.defensics.jenkins.test.utils.Constants.CERTIFICATE_VA
 import static com.synopsys.defensics.jenkins.test.utils.Constants.LOCAL_URL;
 import static com.synopsys.defensics.jenkins.test.utils.Constants.NAME;
 import static com.synopsys.defensics.jenkins.test.utils.Constants.PIPELINE_ERROR_TEXT;
-import static java.lang.Thread.sleep;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -73,7 +72,7 @@ public class RunPipelineIT {
 
   @After
   public void stopServer() {
-    mockServer.stop();
+    DefensicsMockServer.stopMockServer(mockServer);
   }
 
   @Test

--- a/src/integration-test/java/com/synopsys/defensics/jenkins/test/utils/Constants.java
+++ b/src/integration-test/java/com/synopsys/defensics/jenkins/test/utils/Constants.java
@@ -19,7 +19,7 @@ package com.synopsys.defensics.jenkins.test.utils;
 public class Constants {
   public static final String NAME = "My Defensics";
   public static final String URL = "http://my.defensics";
-  public static final String LOCAL_URL = "http://localhost:1080";
+  public static final String LOCAL_URL = "http://127.0.0.1:1080";
   public static final boolean CERTIFICATE_VALIDATION_DISABLED = true; // True disables validation
   public static final boolean CERTIFICATE_VALIDATION_ENABLED = false; // False enables validation
   public static final String CREDENTIALS_ID = "test-credentials";

--- a/src/test/java/com/synopsys/defensics/api/ApiServiceTest.java
+++ b/src/test/java/com/synopsys/defensics/api/ApiServiceTest.java
@@ -57,7 +57,7 @@ public class ApiServiceTest {
 
   @After
   public void tearDown() {
-    mockServer.stop();
+    DefensicsMockServer.stopMockServer(mockServer);
   }
 
   @Test

--- a/src/test/java/com/synopsys/defensics/api/ApiServiceTest.java
+++ b/src/test/java/com/synopsys/defensics/api/ApiServiceTest.java
@@ -38,7 +38,7 @@ public class ApiServiceTest {
 
   private static final String SUITE_SETTINGS = "--suite.setting=thisIsFakeSetting";
   private static ClientAndServer mockServer;
-  private static final String DEFENSICS_URL = "http://localhost:1080/";
+  private static final String DEFENSICS_URL = "http://127.0.0.1:1080/";
   private static final String TOKEN = "test-token";
   private static final boolean CERTIFICATE_VALIDATION_DISABLED = false;
   private ApiService api;
@@ -86,7 +86,7 @@ public class ApiServiceTest {
       api.healthCheck();
       fail("Test connection authentication did not return DefensicsRequestException");
     } catch (DefensicsRequestException exception) {
-      final String apiAddress = "http://localhost:1080/api/v2/healthcheck";
+      final String apiAddress = "http://127.0.0.1:1080/api/v2/healthcheck";
 
       assertThat(
           exception.getMessage(),


### PR DESCRIPTION
Fix occasionally failing Github CI Windows builds - some tests failed on "Connection refused" errors. Adds also few other changes:

- Wait that previous mockServer has stopped and released socket before the next test starts
- Use 127.0.0.1 to prevent failing cases where localhost maps to IPv6 address
- Disable flaky tests option in the surefire plugin - tests should pass in the first try

Using PR to test Github CI builds before merge.
