### PR TITLE
Remove parallelization in Jenkins CI builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,9 @@
  https://github.com/jenkins-infra/pipeline-library/
 */
 buildPlugin(
-  forkCount: '1C', // run this number of tests in parallel for faster feedback.  If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores
+  // Run this number of tests in parallel for faster feedback.
+  // If the number terminates with a 'C', the value will be multiplied by the number of available CPU cores.
+  forkCount: '1', 
   useContainerAgent: true, // Set to `false` if you need to use Docker for containerized tests
   configurations: [
     [platform: 'linux', jdk: 21],


### PR DESCRIPTION
Some tests use MockServer at constant port 1080 which can cause port collisions if the tests are run in
parallel.